### PR TITLE
Utilize lastModified times of source and output to skip annotation processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.bsc.maven</groupId>
   <artifactId>maven-processor-plugin-parent</artifactId>
   <packaging>pom</packaging>
-  <version>4.2</version>
+  <version>4.3-SNAPSHOT</version>
   <name>MAVEN PROCESSOR PLUGIN PARENT</name>
   <description>A maven plugin to process annotation for jdk6 at compile time
 

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -13,7 +13,7 @@ This plugin could be considered the 'alter ego' of maven apt plugin http://mojo.
   <parent>
       <groupId>org.bsc.maven</groupId>
       <artifactId>maven-processor-plugin-parent</artifactId>
-      <version>4.2</version>
+      <version>4.3-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.bsc.maven</groupId>
         <artifactId>maven-processor-plugin-parent</artifactId>
-        <version>4.2</version>
+        <version>4.3-SNAPSHOT</version>
     </parent>
 
   <dependencies>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.bsc.maven</groupId>
         <artifactId>maven-processor-plugin-parent</artifactId>
-        <version>4.2</version>
+        <version>4.3-SNAPSHOT</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
The annotation processor should be able to skip the annotation
processing if the sources haven't changed since the last processing.
This will speed up project builds considerably since for example the
JPA metamodel generator will not run if the entities haven't been
modified, which will save the compiler of having to recompile your
whole module.

Using the option `skipWithoutSourceChanges` you can enable this
behavior. By default it is turned off to maintain the current behavior.

This change doesn't track individual files, as there need not be a 1-1
mapping between the origin of the annotation processor and the
generated sources. The plugin rather determines from all source
locations what the most recent last modified time is, and does the same
for all the files in the output folder.

This cuts down rebuild times on my current project by a half or so
(going from over 2 minutes to just 1 minute).
