### PR TITLE
Adds support to -processorpath

### DIFF
--- a/processor/src/main/java/org/bsc/maven/plugin/processor/DependencyCoordinate.java
+++ b/processor/src/main/java/org/bsc/maven/plugin/processor/DependencyCoordinate.java
@@ -1,0 +1,91 @@
+package org.bsc.maven.plugin.processor;
+
+import java.util.Objects;
+
+/**
+ * Maven-coordinates of a dependency.
+ * 
+ * @author Ulysses R. Ribeiro
+ *
+ */
+public class DependencyCoordinate {
+
+    private String groupId;
+
+    private String artifactId;
+
+    private String version;
+
+    private String classifier;
+
+    private String type = "jar";
+
+	public String getGroupId() {
+		return this.groupId;
+	}
+
+	public void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	public String getArtifactId() {
+		return this.artifactId;
+	}
+
+	public void setArtifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+
+	public String getVersion() {
+		return this.version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public String getClassifier() {
+		return this.classifier;
+	}
+
+	public void setClassifier(String classifier) {
+		this.classifier = classifier;
+	}
+
+	public String getType() {
+		return this.type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(artifactId, classifier, groupId, type, version);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		DependencyCoordinate other = (DependencyCoordinate) obj;
+		return Objects.equals(artifactId, other.artifactId) && Objects.equals(classifier, other.classifier)
+				&& Objects.equals(groupId, other.groupId) && Objects.equals(type, other.type)
+				&& Objects.equals(version, other.version);
+	}
+
+	@Override
+	public String toString() {
+		return "DependencyCoordinate [groupId=" + groupId + ", artifactId=" + artifactId + ", version=" + version
+				+ ", classifier=" + classifier + ", type=" + type + "]";
+	}
+    
+}


### PR DESCRIPTION
Libraries like [Google AutoValue](https://github.com/google/auto/blob/master/value/userguide/index.md) and [MapStruct](https://mapstruct.org/documentation/installation/) have split artifacts for the annotations and the actual processor. This approach combined with the "-processorpath" argument avoids pulling unnecessary classes into the runtime classpath, which I believe should be the preferred approach when possible.

This change is JDK8 compatible, as I'm hoping to use it with that version and was mostly adapted from maven-compiler-plugin.

Sample usage:
```
...
<properties>
    <mapstruct.version>1.4.2.Final</mapstruct.version>
</properties>
...
<dependencies>
    <dependency>
        <groupId>org.mapstruct</groupId>
        <artifactId>mapstruct</artifactId>
        <version>${mapstruct.version}</version>
    </dependency>
</dependencies>
...
<build>
    <plugins>
	<plugin>
		<groupId>org.bsc.maven</groupId>
		<artifactId>maven-processor-plugin</artifactId>
		<version>5.0-jdk8-rc1</version>
		<executions>
			<execution>
				<id>process</id>
				<goals>
					<goal>process</goal>
				</goals>
				<phase>generate-sources</phase>
			</execution>
		</executions>
		<configuration>
			<annotationProcessorPaths>
				<annotationProcessorPath>
					<groupId>org.mapstruct</groupId>
					<artifactId>mapstruct-processor</artifactId>
					<version>${mapstruct.version}</version>
				</annotationProcessorPath>
			</annotationProcessorPaths>
		</configuration>
	</plugin>
    </plugins>
</build>
```
