### PR TITLE
Fix -processorpath joining char.

### DIFF
--- a/processor/src/main/java/org/bsc/maven/plugin/processor/AbstractAnnotationProcessorMojo.java
+++ b/processor/src/main/java/org/bsc/maven/plugin/processor/AbstractAnnotationProcessorMojo.java
@@ -1048,6 +1048,6 @@ public abstract class AbstractAnnotationProcessorMojo extends AbstractMojo {
   protected Optional<String> buildProcessorPath()  {
     return this.resolveProcessorPathEntries()
             .flatMap( artifactPaths ->
-                    Optional.of(artifactPaths.stream().collect(Collectors.joining(File.separator))) );
+                    Optional.of(artifactPaths.stream().collect(Collectors.joining(File.pathSeparator))) );
   }
 }


### PR DESCRIPTION
Hi, when merging my previous PR (#95) a small bug was introduced:

```java
private Optional<String> buildProcessorPath() throws MojoExecutionException {
    Optional<List<String>> processorPathEntries = this.resolveProcessorPathEntries();
    return processorPathEntries.map(value -> StringUtils.join(value.iterator(), File.pathSeparator));
}
```

became:
```java
protected Optional<String> buildProcessorPath()  {
  return this.resolveProcessorPathEntries()
          .flatMap( artifactPaths ->
                  Optional.of(artifactPaths.stream().collect(Collectors.joining(File.separator))) );
}
```
Which produces an invalid parameter string due to the wrong separator character.

Again, thanks for your time.
