### PR TITLE
Fixed unchanged sources check

### DIFF
--- a/processor/src/main/java/org/bsc/maven/plugin/processor/AbstractAnnotationProcessorMojo.java
+++ b/processor/src/main/java/org/bsc/maven/plugin/processor/AbstractAnnotationProcessorMojo.java
@@ -597,7 +597,8 @@ public abstract class AbstractAnnotationProcessorMojo extends AbstractMojo {
   }
 
   private boolean isSourcesUnchanged(List<JavaFileObject> allSources) throws IOException {
-    if (!areSourceFilesSameAsPreviousRun(allSources))
+    Path sourceFileList = outputDirectory.toPath().resolve(".maven-processor-source-files.txt");
+    if (!areSourceFilesSameAsPreviousRun(allSources, sourceFileList))
       return false;
 
     long maxSourceDate = allSources.stream()
@@ -612,7 +613,7 @@ public abstract class AbstractAnnotationProcessorMojo extends AbstractMojo {
       @Override
       public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
           throws IOException {
-        if (Files.isRegularFile(file)) {
+        if (Files.isRegularFile(file) && !file.equals(sourceFileList)) {
           maxOutputDate.updateAndGet(t -> Math.max(t, file.toFile().lastModified()));
         }
         return FileVisitResult.CONTINUE;
@@ -631,11 +632,11 @@ public abstract class AbstractAnnotationProcessorMojo extends AbstractMojo {
    * Checks the list of {@code allSources} against the stored list of source files in a previous run.
    *
    * @param allSources
+   * @param sourceFileList
    * @return {@code true} when the filenames of the previous run matches exactly with the current run.
    * @throws IOException
    */
-  private boolean areSourceFilesSameAsPreviousRun(List<JavaFileObject> allSources) throws IOException {
-    Path sourceFileList = outputDirectory.toPath().resolve(".maven-processor-source-files.txt");
+  private boolean areSourceFilesSameAsPreviousRun(List<JavaFileObject> allSources, Path sourceFileList) throws IOException {
     try {
       if (!Files.exists(sourceFileList)) {
         getLog().debug("File with previous sources " + sourceFileList + " not found, treating as first run");


### PR DESCRIPTION
When attempting to use flag `skipSourcesUnchanged` in a code base that generates mapping code via MapStruct, I realized the flag is overworking, in that changed source files too were skipped. The issue seems to reside in `lastModified` check being polluted by file `.maven-processor-source-files.txt`, that is rewritten in method `areSourceFilesSameAsPreviousRun` (which seems to be part of the problem, as you would not expect this method to be in charge of rewriting the file, which should instead be generated at the very end) : as a consequence, its `lastModified` date is inevitably the most recent one, hence it comes after all source files' ones, which results in method `isSourcesUnchanged` always returning `true`.

I wonder whether another possible approach could be to compare `maxSourceDate` with `minOutputDate`, instead that `maxOutputDate`.